### PR TITLE
Add optional label argument to open_console

### DIFF
--- a/pycony/__init__.py
+++ b/pycony/__init__.py
@@ -32,11 +32,15 @@ import pdb
 readline.clear_history()
 
 
-def open_console():
+def open_console(label=None):
     """
     Opens an interactive Python console with access to the current scope.
+    Optionally prints a context label where the console is inserted.
     Includes a try-except block to prevent crashes during console initialization.
     Accesses both local and global variables.
+
+    Args:
+        label (str, optional): Contextual label to print before opening the console.
     """
     frame = inspect.currentframe().f_back
     globals_dict = frame.f_globals
@@ -45,6 +49,9 @@ def open_console():
     # Combine locals and globals into a single dictionary for the console
     combined_scope = locals_dict.copy()
     combined_scope.update(globals_dict)
+
+    if label is not None:
+        print(f"[open_console] Context label: {label}")
 
     try:
         console = code.InteractiveConsole(combined_scope)


### PR DESCRIPTION
This PR adds an optional label argument to the open_console function, addressing #1.